### PR TITLE
feat:Popover컴포넌트화

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
     <html lang='ko'>
       <body className={`${pretendard.variable} font-pretendard bg-slate-100`}>
         <NextUIProvider>
-          <SideMenu />
+          {/* <SideMenu /> */}
           {children}
         </NextUIProvider>
       </body>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
     <html lang='ko'>
       <body className={`${pretendard.variable} font-pretendard bg-slate-100`}>
         <NextUIProvider>
-          {/* <SideMenu /> */}
+          <SideMenu />
           {children}
         </NextUIProvider>
       </body>

--- a/assets/svgs/IcArrowDown.tsx
+++ b/assets/svgs/IcArrowDown.tsx
@@ -1,0 +1,7 @@
+import React, { SVGProps } from 'react';
+
+export const IcArrowDown = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' {...props}>
+    <path d='M7.5 10L12 14.5L16.5 10' stroke='#334155' strokeWidth='1.8' strokeLinecap='round' strokeLinejoin='round' />
+  </svg>
+);

--- a/assets/svgs/Plus.tsx
+++ b/assets/svgs/Plus.tsx
@@ -1,8 +1,12 @@
 import React, { SVGProps } from 'react';
 
-export const Plus = (props: SVGProps<SVGSVGElement>) => (
+type PlusProps = SVGProps<SVGSVGElement> & {
+  strokeColor?: string;
+};
+
+export const Plus = ({ strokeColor = 'white', ...props }: PlusProps) => (
   <svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' {...props}>
-    <path d='M5 12H18.5' stroke='white' strokeWidth='1.8' strokeLinecap='round' />
-    <path d='M11.75 18.75V5.25' stroke='white' strokeWidth='1.8' strokeLinecap='round' />
+    <path d='M5 12H18.5' stroke={strokeColor} strokeWidth='1.8' strokeLinecap='round' />
+    <path d='M11.75 18.75V5.25' stroke={strokeColor} strokeWidth='1.8' strokeLinecap='round' />
   </svg>
 );

--- a/assets/svgs/index.ts
+++ b/assets/svgs/index.ts
@@ -17,3 +17,4 @@ export * from './PlusBlue';
 export * from './Plus';
 export * from './SideFoldButton';
 export * from './Rectangles';
+export * from './IcArrowDown';

--- a/components/CardGoal/CardGoal.tsx
+++ b/components/CardGoal/CardGoal.tsx
@@ -1,21 +1,28 @@
 'use client';
 
 import { Todo } from '@/types/Todo';
-import ListTodo from '../ListTodo/ListTodo';
 import { useEffect, useState } from 'react';
 import { IcArrowDown, Plus } from '@/assets/svgs';
 import ProgressBar from '../ProgressBar/ProgressBar';
+import ListTodoProgress from './ListTodoProgress';
 
 type CardGoalProps = {
   list: Todo[];
 };
 
 export default function CardGoal({ list }: CardGoalProps) {
-  const [todoList, setTodoList] = useState(list || []);
+  const [todoList, setTodoList] = useState(list);
   const [progress, setProgress] = useState(0);
   const doneList = todoList.filter((item) => item.done === true);
   const incompleteList = todoList.filter((item) => item.done === false);
 
+  const onUpdateList = (buttonType: string, id: number) => {
+    if (buttonType === 'done') {
+      setTodoList((prev) => prev.map((item) => (item.id === id ? { ...item, done: !item.done } : item)));
+    }
+  };
+
+  //진행도는 추후 백엔드 API로 받을 예정
   useEffect(() => {
     const progress = (doneList.length / todoList.length) * 100;
     setProgress(progress);
@@ -25,7 +32,7 @@ export default function CardGoal({ list }: CardGoalProps) {
     <div className='flex w-[568px] h-[352px] p-6 flex-col gap-4 justify-start bg-blue-50 rounded-[32px]'>
       <div className='flex flex-col gap-2'>
         <div className='flex justify-between'>
-          <h1 className='text-lg font-bold'>{list[0].goal?.title}</h1>
+          <h1 className='text-lg font-bold'>{list?.[0]?.goal?.title || '등록한 목표가 없습니다.'}</h1>
           <button className='flex items-center gap-1 text-sm font-semibold text-blue-500'>
             <Plus strokeColor='currentColor' className='w-4 h-4' />
             할일 추가
@@ -34,43 +41,11 @@ export default function CardGoal({ list }: CardGoalProps) {
         <ProgressBar value={progress} />
       </div>
       <div className='grid grid-cols-2 gap-6'>
-        <div className='flex flex-col gap-3 h-[184px]'>
-          <span className='text-sm font-semibold text-slate-800'>To do</span>
-          {incompleteList.length !== 0 ? (
-            <ListTodo
-              todos={incompleteList}
-              goalHidden
-              viewLength={5}
-              onButtonClick={(buttonType, id) => {
-                if (buttonType === 'done') {
-                  setTodoList((prev) => prev.map((item) => (item.id === id ? { ...item, done: true } : item)));
-                }
-              }}
-            />
-          ) : (
-            <span className='text-xs text-slate-500'>아직 해야할 일이 없어요</span>
-          )}
-        </div>
-        <div className='flex flex-col'>
-          <span className='text-sm font-semibold text-slate-800'>Done</span>
-          {doneList.length !== 0 ? (
-            <ListTodo
-              todos={doneList}
-              viewLength={5}
-              goalHidden
-              onButtonClick={(buttonType, id) => {
-                if (buttonType === 'done') {
-                  setTodoList((prev) => prev.map((item) => (item.id === id ? { ...item, done: false } : item)));
-                }
-              }}
-            />
-          ) : (
-            <span className='text-xs text-slate-500'>아직 다 한 일이 없어요</span>
-          )}
-        </div>
+        <ListTodoProgress itemList={incompleteList} onUpdateList={onUpdateList} textValue={'아직 해야할 일이 없어요'} />
+        <ListTodoProgress itemList={doneList} onUpdateList={onUpdateList} textValue={'아직 다 한 일이 없어요'} />
       </div>
-      <div className='flex justify-center h-8'>
-        <button className='flex items-center justify-center gap-2 bg-white py-1.5 pr-[21px] pl-[36px] rounded-2xl'>
+      <div className='flex justify-center min-h-0'>
+        <button className='flex items-center justify-center text-xs font-semibold py-1  gap-2 bg-white pr-[21px] pl-[36px] rounded-2xl'>
           더보기
           <IcArrowDown className='w-6 h-6' />
         </button>

--- a/components/CardGoal/CardGoal.tsx
+++ b/components/CardGoal/CardGoal.tsx
@@ -40,6 +40,7 @@ export default function CardGoal({ list }: CardGoalProps) {
           {incompleteList.length !== 0 ? (
             <ListTodo
               todos={incompleteList}
+              goalHidden
               viewLength={5}
               onButtonClick={(buttonType, id) => {
                 if (buttonType === 'done') {

--- a/components/CardGoal/CardGoal.tsx
+++ b/components/CardGoal/CardGoal.tsx
@@ -3,7 +3,6 @@
 import { Todo } from '@/types/Todo';
 import ListTodo from '../ListTodo/ListTodo';
 import { useEffect, useState } from 'react';
-import { Button, Progress } from '@nextui-org/react';
 import { IcArrowDown, Plus } from '@/assets/svgs';
 import ProgressBar from '../ProgressBar/ProgressBar';
 

--- a/components/CardGoal/CardGoal.tsx
+++ b/components/CardGoal/CardGoal.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { Todo } from '@/types/Todo';
+import ListTodo from '../ListTodo/ListTodo';
+import { useEffect, useState } from 'react';
+import { Button, Progress } from '@nextui-org/react';
+import { IcArrowDown, Plus } from '@/assets/svgs';
+import ProgressBar from '../ProgressBar/ProgressBar';
+
+type CardGoalProps = {
+  list: Todo[];
+};
+
+export default function CardGoal({ list }: CardGoalProps) {
+  const [todoList, setTodoList] = useState(list || []);
+  const [progress, setProgress] = useState(0);
+  const doneList = todoList.filter((item) => item.done === true);
+  const incompleteList = todoList.filter((item) => item.done === false);
+
+  useEffect(() => {
+    const progress = (doneList.length / todoList.length) * 100;
+    setProgress(progress);
+  }, [todoList]);
+
+  return (
+    <div className='flex w-[568px] h-[352px] p-6 flex-col gap-4 justify-start bg-blue-50 rounded-[32px]'>
+      <div className='flex flex-col gap-2'>
+        <div className='flex justify-between'>
+          <h1 className='text-lg font-bold'>{list[0].goal?.title}</h1>
+          <button className='flex items-center gap-1 text-sm font-semibold text-blue-500'>
+            <Plus strokeColor='currentColor' className='w-4 h-4' />
+            할일 추가
+          </button>
+        </div>
+        <ProgressBar value={progress} />
+      </div>
+      <div className='grid grid-cols-2 gap-6'>
+        <div className='flex flex-col gap-3 h-[184px]'>
+          <span className='text-sm font-semibold text-slate-800'>To do</span>
+          {incompleteList.length !== 0 ? (
+            <ListTodo
+              todos={incompleteList}
+              viewLength={5}
+              onButtonClick={(buttonType, id) => {
+                if (buttonType === 'done') {
+                  setTodoList((prev) => prev.map((item) => (item.id === id ? { ...item, done: true } : item)));
+                }
+              }}
+            />
+          ) : (
+            <span className='text-xs text-slate-500'>아직 해야할 일이 없어요</span>
+          )}
+        </div>
+        <div className='flex flex-col'>
+          <span className='text-sm font-semibold text-slate-800'>Done</span>
+          {doneList.length !== 0 ? (
+            <ListTodo
+              todos={doneList}
+              viewLength={5}
+              goalHidden
+              onButtonClick={(buttonType, id) => {
+                if (buttonType === 'done') {
+                  setTodoList((prev) => prev.map((item) => (item.id === id ? { ...item, done: false } : item)));
+                }
+              }}
+            />
+          ) : (
+            <span className='text-xs text-slate-500'>아직 다 한 일이 없어요</span>
+          )}
+        </div>
+      </div>
+      <div className='flex justify-center h-8'>
+        <button className='flex items-center justify-center gap-2 bg-white py-1.5 pr-[21px] pl-[36px] rounded-2xl'>
+          더보기
+          <IcArrowDown className='w-6 h-6' />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/CardGoal/ListTodoProgress.tsx
+++ b/components/CardGoal/ListTodoProgress.tsx
@@ -1,0 +1,22 @@
+import { Todo } from '@/types/Todo';
+import ListTodo from '../ListTodo/ListTodo';
+import { Dispatch } from 'react';
+
+type ListTodoProgressProps = {
+  itemList: Todo[];
+  textValue: string;
+  onUpdateList: (buttonType: string, id: number) => void;
+};
+
+export default function ListTodoProgress({ itemList, textValue, onUpdateList }: ListTodoProgressProps) {
+  return (
+    <div className='flex flex-col gap-4'>
+      <span className='text-sm font-semibold text-slate-800'>To do</span>
+      {itemList.length !== 0 ? (
+        <ListTodo todos={itemList} showGoal={false} displayTodoCount={5} onButtonClick={onUpdateList} />
+      ) : (
+        <span className='flex -mt-0.5 justify-center items-center h-[152px] text-xs text-slate-500'>{textValue}</span>
+      )}
+    </div>
+  );
+}

--- a/components/ListTodo/ListTodo.tsx
+++ b/components/ListTodo/ListTodo.tsx
@@ -1,22 +1,23 @@
 'use client';
 
-import { Todo, ListTodoButtons } from '@/types/Todo';
+import { ListTodoButtons, Todo } from '@/types/Todo';
 import { Checkbox } from '@nextui-org/react';
-import { useState, useRef } from 'react';
-import { Kebab, Goal, File, Link, Note, NoteWrite } from '@/assets/svgs';
+import { Kebab, Goal } from '@/assets/svgs';
+import { useRef, useState } from 'react';
+import TodoListButtons from './TodoListButtons';
 import Popover from '../Popover/Popover';
 
 type ListTodoProps = {
   todos: Todo[];
   onButtonClick: (buttonType: ListTodoButtons, id: number) => void;
-  goalHidden?: boolean;
-  viewLength?: number;
+  showGoal: boolean;
+  displayTodoCount?: number;
 };
 
-export default function ListTodo({ todos, goalHidden = false, viewLength = 0, onButtonClick }: ListTodoProps) {
+export default function ListTodo({ todos, showGoal = true, displayTodoCount = 0, onButtonClick }: ListTodoProps) {
   const [openPopupTodoId, setOpenPopupTodoId] = useState<number | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
-  const todoList = viewLength ? todos.slice(0, viewLength) : todos.slice(0);
+  const todoList = displayTodoCount ? todos.slice(0, displayTodoCount) : todos.slice(0);
   //최신순으로 정렬
   todos.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
   const handleClick = (buttonType: ListTodoButtons, id: number) => {
@@ -24,29 +25,29 @@ export default function ListTodo({ todos, goalHidden = false, viewLength = 0, on
   };
 
   return (
-    <div className='mt-3'>
+    <div className='-mt-0.5'>
       <div className='flex flex-col justify-center items-start gap-[10px]'>
         {todoList.map((item) => {
           return (
             <Checkbox
               classNames={{
                 base: ['flex max-w-full w-full justify-between items-start group p-0 m-0'],
-                label: ['w-full'],
-                wrapper: ['w-[18px] h-[18px]'],
+                label: ['w-full pl-2 min-w-0'],
+                wrapper: ['w-[18px] h-[18px] m-0'],
               }}
               defaultSelected={item.done}
               onChange={() => handleClick('done', item.id)}
               key={item.id}
             >
-              <div className='flex justify-between items-stretch truncate'>
+              <div className='flex justify-between items-stretch'>
                 <div
-                  data-goalhidden={goalHidden}
-                  className='data-[goalHidden=false]:flex-col data-[goalHidden=false]:items-start flex items-center justify-start truncate'
+                  data-showgoal={showGoal}
+                  className='data-[showgoal=true]:flex-col data-[showgoal=true]:items-start flex items-center justify-start truncate'
                 >
-                  <span className='group-data-[selected=true]:line-through text-sm text-slate-800 py-0.5'>
+                  <span className='group-data-[selected=true]:line-through text-sm text-slate-800 py-0.5 truncate flex-shrink'>
                     {item.title}
                   </span>
-                  {item.goal && !goalHidden && (
+                  {item.goal && showGoal && (
                     <span className='flex justify-center items-center gap-1.5 !no-underline text-sm text-slate-700'>
                       <Goal className='w-6 h-6 ' />
                       {item.goal.title}
@@ -54,27 +55,7 @@ export default function ListTodo({ todos, goalHidden = false, viewLength = 0, on
                   )}
                 </div>
                 <div className='flex justify-center items-center gap-1'>
-                  {item.fileUrl && (
-                    <button onClick={() => handleClick('file', item.id)}>
-                      <File className='w-6 h-6' />
-                    </button>
-                  )}
-                  {item.linkUrl && (
-                    <button onClick={() => handleClick('link', item.id)}>
-                      <Link className='w-6 h-6' />
-                    </button>
-                  )}
-                  {item.noteId && (
-                    <button onClick={() => handleClick('note', item.id)}>
-                      <Note className='w-6 h-6' />
-                    </button>
-                  )}
-                  <button
-                    className='h-0 overflow-hidden group-hover:h-6'
-                    onClick={() => handleClick('note write', item.id)}
-                  >
-                    <NoteWrite className='w-6 h-6' />
-                  </button>
+                  <TodoListButtons item={item} handleClick={handleClick} />
                   <Popover
                     openPopupId={openPopupTodoId}
                     handlePopupClick={handleClick}

--- a/components/ListTodo/ListTodo.tsx
+++ b/components/ListTodo/ListTodo.tsx
@@ -10,11 +10,14 @@ type ListTodoButtons = 'file' | 'link' | 'note write' | 'done' | 'note' | 'edit'
 type ListTodoProps = {
   todos: Todo[];
   onButtonClick: (buttonType: ListTodoButtons, id: number) => void;
+  goalHidden?: boolean;
+  viewLength?: number;
 };
 
-export default function ListTodo({ todos, onButtonClick }: ListTodoProps) {
+export default function ListTodo({ todos, goalHidden = false, viewLength = 0, onButtonClick }: ListTodoProps) {
   const [openPopupTodoId, setOpenPopupTodoId] = useState<number | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
+  const todoList = viewLength ? todos.slice(0, viewLength) : todos.slice(0);
   //최신순으로 정렬
   todos.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
   const handleClick = (buttonType: ListTodoButtons, id: number) => {
@@ -32,24 +35,29 @@ export default function ListTodo({ todos, onButtonClick }: ListTodoProps) {
   }, [openPopupTodoId]);
 
   return (
-    <div className='min-w-max'>
-      <div className='flex flex-col justify-center items-start gap-5 py-3.5 px-5'>
-        {todos.map((item) => {
+    <div className='mt-3'>
+      <div className='flex flex-col justify-center items-start gap-[10px]'>
+        {todoList.map((item) => {
           return (
             <Checkbox
               classNames={{
-                base: ['flex items-center w-full max-w-full group p-0'],
-                label: ['max-w-full w-full '],
+                base: ['flex max-w-full w-full justify-between items-start group p-0 m-0'],
+                label: ['w-full'],
                 wrapper: ['w-[18px] h-[18px]'],
               }}
               defaultSelected={item.done}
               onChange={() => handleClick('done', item.id)}
               key={item.id}
             >
-              <div className='flex justify-between items-stretch'>
-                <div className='flex flex-col items-start justify-center'>
-                  <span className='group-data-[selected=true]:line-through text-sm text-slate-800'>{item.title}</span>
-                  {item.goal && (
+              <div className='flex justify-between items-stretch truncate'>
+                <div
+                  data-goalhidden={goalHidden}
+                  className='data-[goalHidden=false]:flex-col data-[goalHidden=false]:items-start flex items-center justify-start truncate'
+                >
+                  <span className='group-data-[selected=true]:line-through text-sm text-slate-800 py-0.5'>
+                    {item.title}
+                  </span>
+                  {item.goal && !goalHidden && (
                     <span className='flex justify-center items-center gap-1.5 !no-underline text-sm text-slate-700'>
                       <Goal className='w-6 h-6 ' />
                       {item.goal.title}

--- a/components/ListTodo/ListTodo.tsx
+++ b/components/ListTodo/ListTodo.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import { Todo } from '@/types/Todo';
-import { Checkbox, Popover, PopoverContent, PopoverTrigger } from '@nextui-org/react';
+import { Todo, ListTodoButtons } from '@/types/Todo';
+import { Checkbox } from '@nextui-org/react';
+import { useState, useRef } from 'react';
 import { Kebab, Goal, File, Link, Note, NoteWrite } from '@/assets/svgs';
-import { useEffect, useRef, useState } from 'react';
-
-type ListTodoButtons = 'file' | 'link' | 'note write' | 'done' | 'note' | 'edit' | 'delete';
+import Popover from '../Popover/Popover';
 
 type ListTodoProps = {
   todos: Todo[];
@@ -23,16 +22,6 @@ export default function ListTodo({ todos, goalHidden = false, viewLength = 0, on
   const handleClick = (buttonType: ListTodoButtons, id: number) => {
     onButtonClick(buttonType, id);
   };
-
-  useEffect(() => {
-    const outsideClick = (e: MouseEvent) => {
-      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
-        setOpenPopupTodoId(null);
-      }
-    };
-    document.addEventListener('mousedown', outsideClick);
-    return () => document.removeEventListener('mousedown', outsideClick);
-  }, [openPopupTodoId]);
 
   return (
     <div className='mt-3'>
@@ -87,46 +76,24 @@ export default function ListTodo({ todos, goalHidden = false, viewLength = 0, on
                     <NoteWrite className='w-6 h-6' />
                   </button>
                   <Popover
-                    isOpen={openPopupTodoId === item.id}
-                    radius='none'
-                    classNames={{ content: ['rounded-xl border-0 p-0'] }}
+                    openPopupId={openPopupTodoId}
+                    handlePopupClick={handleClick}
+                    setOpenPopupId={setOpenPopupTodoId}
+                    item={item}
+                    goal
                   >
-                    <PopoverTrigger className='focus-visible:outline-none'>
-                      <button
-                        className='hidden group-hover:block'
-                        onClick={() => {
-                          if (openPopupTodoId) {
-                            setOpenPopupTodoId(null);
-                          } else {
-                            setOpenPopupTodoId(item.id);
-                          }
-                        }}
-                      >
-                        <Kebab className='w-6 h-6' />
-                      </button>
-                    </PopoverTrigger>
-                    <PopoverContent>
-                      <div className='flex flex-col text-sm text-slate-700' ref={popoverRef}>
-                        <button
-                          className='px-4 pt-2 pb-1.5 rounded-lg focus-visible:outline-none hover:bg-slate-200'
-                          onClick={() => {
-                            handleClick('edit', item.id);
-                            setOpenPopupTodoId(null);
-                          }}
-                        >
-                          수정하기
-                        </button>
-                        <button
-                          className='px-4 pt-1.5 rounded-lg pb-2 focus-visible:outline-none hover:bg-slate-200'
-                          onClick={() => {
-                            handleClick('delete', item.id);
-                            setOpenPopupTodoId(null);
-                          }}
-                        >
-                          삭제하기
-                        </button>
-                      </div>
-                    </PopoverContent>
+                    <button
+                      className='hidden group-hover:block'
+                      onClick={() => {
+                        if (openPopupTodoId) {
+                          setOpenPopupTodoId(null);
+                        } else {
+                          setOpenPopupTodoId(item.id);
+                        }
+                      }}
+                    >
+                      <Kebab className='w-6 h-6' />
+                    </button>
                   </Popover>
                 </div>
               </div>

--- a/components/ListTodo/ListTodo.tsx
+++ b/components/ListTodo/ListTodo.tsx
@@ -62,20 +62,7 @@ export default function ListTodo({ todos, showGoal = true, displayTodoCount = 0,
                     setOpenPopupId={setOpenPopupTodoId}
                     item={item}
                     goal
-                  >
-                    <button
-                      className='hidden group-hover:block'
-                      onClick={() => {
-                        if (openPopupTodoId) {
-                          setOpenPopupTodoId(null);
-                        } else {
-                          setOpenPopupTodoId(item.id);
-                        }
-                      }}
-                    >
-                      <Kebab className='w-6 h-6' />
-                    </button>
-                  </Popover>
+                  />
                 </div>
               </div>
             </Checkbox>

--- a/components/ListTodo/ListTodo.tsx
+++ b/components/ListTodo/ListTodo.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { ListTodoButtons, Todo } from '@/types/Todo';
-import { Checkbox } from '@nextui-org/react';
-import { Kebab, Goal } from '@/assets/svgs';
-import { useRef, useState } from 'react';
 import TodoListButtons from './TodoListButtons';
+import { Todo, ListTodoButtons } from '@/types/Todo';
+import { Checkbox } from '@nextui-org/react';
+import { useState } from 'react';
+import { Goal } from '@/assets/svgs';
 import Popover from '../Popover/Popover';
 
 type ListTodoProps = {
@@ -16,7 +16,6 @@ type ListTodoProps = {
 
 export default function ListTodo({ todos, showGoal = true, displayTodoCount = 0, onButtonClick }: ListTodoProps) {
   const [openPopupTodoId, setOpenPopupTodoId] = useState<number | null>(null);
-  const popoverRef = useRef<HTMLDivElement | null>(null);
   const todoList = displayTodoCount ? todos.slice(0, displayTodoCount) : todos.slice(0);
   //최신순으로 정렬
   todos.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());

--- a/components/ListTodo/TodoListButtons.tsx
+++ b/components/ListTodo/TodoListButtons.tsx
@@ -1,0 +1,31 @@
+import { File, Link, Note, NoteWrite } from '@/assets/svgs';
+import { ListTodoButtons, Todo } from '@/types/Todo';
+
+type TodoListButtonsProps = {
+  item: Todo;
+  handleClick: (buttonType: ListTodoButtons, id: number) => void;
+};
+export default function TodoListButtons({ item, handleClick }: TodoListButtonsProps) {
+  return (
+    <>
+      {item.fileUrl && (
+        <button onClick={() => handleClick('file', item.id)}>
+          <File className='w-6 h-6' />
+        </button>
+      )}
+      {item.linkUrl && (
+        <button onClick={() => handleClick('link', item.id)}>
+          <Link className='w-6 h-6' />
+        </button>
+      )}
+      {item.noteId && (
+        <button onClick={() => handleClick('note', item.id)}>
+          <Note className='w-6 h-6' />
+        </button>
+      )}
+      <button className='hidden group-hover:block' onClick={() => handleClick('note write', item.id)}>
+        <NoteWrite className='w-6 h-6' />
+      </button>
+    </>
+  );
+}

--- a/components/Popover/Popover.tsx
+++ b/components/Popover/Popover.tsx
@@ -1,0 +1,64 @@
+import { ListTodoButtons, Todo } from '@/types/ListTodo/Todos';
+import { Popover as NextPopover, PopoverTrigger, PopoverContent } from '@nextui-org/react';
+import { Dispatch, ReactNode, useEffect, useRef } from 'react';
+
+type PopoverProps = {
+  item: Todo;
+  children: ReactNode;
+  openPopupId: number | null;
+  handlePopupClick: (buttonType: ListTodoButtons, id: number) => void;
+  setOpenPopupId: Dispatch<number | null>;
+  goal?: boolean;
+};
+
+export default function Popover({ item, children, openPopupId, handlePopupClick, setOpenPopupId, goal }: PopoverProps) {
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const outsideClick = (e: MouseEvent) => {
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+        setOpenPopupId(null);
+      }
+    };
+    document.addEventListener('mousedown', outsideClick);
+    return () => document.removeEventListener('mousedown', outsideClick);
+  }, [openPopupId]);
+  return (
+    <NextPopover isOpen={openPopupId === item.id} radius='none' classNames={{ content: ['rounded-xl border-0 p-0'] }}>
+      <PopoverTrigger className='focus-visible:outline-none'>{children}</PopoverTrigger>
+      <PopoverContent>
+        <div className='flex flex-col text-sm text-slate-700' ref={popoverRef}>
+          {goal && (
+            <button
+              className='px-4 pt-2 pb-1.5 rounded-lg focus-visible:outline-none hover:bg-slate-200'
+              onClick={() => {
+                handlePopupClick('note read', item.id);
+                setOpenPopupId(null);
+              }}
+            >
+              노트 보기
+            </button>
+          )}
+          <button
+            className='px-4 pt-2 pb-1.5 rounded-lg focus-visible:outline-none hover:bg-slate-200'
+            onClick={() => {
+              handlePopupClick('edit', item.id);
+              setOpenPopupId(null);
+            }}
+          >
+            수정하기
+          </button>
+          <button
+            className='px-4 pt-1.5 rounded-lg pb-2 focus-visible:outline-none hover:bg-slate-200'
+            onClick={() => {
+              handlePopupClick('delete', item.id);
+              setOpenPopupId(null);
+            }}
+          >
+            삭제하기
+          </button>
+        </div>
+      </PopoverContent>
+    </NextPopover>
+  );
+}

--- a/components/Popover/Popover.tsx
+++ b/components/Popover/Popover.tsx
@@ -24,7 +24,11 @@ export default function Popover({ item, children, openPopupId, handlePopupClick,
     return () => document.removeEventListener('mousedown', outsideClick);
   }, [openPopupId]);
   return (
-    <NextPopover isOpen={openPopupId === item.id} radius='none' classNames={{ content: ['rounded-xl border-0 p-0'] }}>
+    <NextPopover
+      isOpen={goal ? typeof openPopupId === 'number' : openPopupId === item.id}
+      radius='none'
+      classNames={{ content: ['rounded-xl border-0 p-0'] }}
+    >
       <PopoverTrigger className='focus-visible:outline-none'>{children}</PopoverTrigger>
       <PopoverContent>
         <div className='flex flex-col text-sm text-slate-700' ref={popoverRef}>

--- a/components/Popover/Popover.tsx
+++ b/components/Popover/Popover.tsx
@@ -1,7 +1,7 @@
 import { Kebab } from '@/assets/svgs';
 import { ListTodoButtons, Todo } from '@/types/Todo';
 import { Popover as NextPopover, PopoverTrigger, PopoverContent } from '@nextui-org/react';
-import { Dispatch, ReactNode, useEffect, useRef } from 'react';
+import { Dispatch, useEffect, useRef } from 'react';
 
 type PopoverProps = {
   item: Todo;

--- a/components/Popover/Popover.tsx
+++ b/components/Popover/Popover.tsx
@@ -1,17 +1,17 @@
+import { Kebab } from '@/assets/svgs';
 import { ListTodoButtons, Todo } from '@/types/Todo';
 import { Popover as NextPopover, PopoverTrigger, PopoverContent } from '@nextui-org/react';
 import { Dispatch, ReactNode, useEffect, useRef } from 'react';
 
 type PopoverProps = {
   item: Todo;
-  children: ReactNode;
   openPopupId: number | null;
   handlePopupClick: (buttonType: ListTodoButtons, id: number) => void;
   setOpenPopupId: Dispatch<number | null>;
   goal?: boolean;
 };
 
-export default function Popover({ item, children, openPopupId, handlePopupClick, setOpenPopupId, goal }: PopoverProps) {
+export default function Popover({ item, openPopupId, handlePopupClick, setOpenPopupId, goal }: PopoverProps) {
   const popoverRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -29,7 +29,20 @@ export default function Popover({ item, children, openPopupId, handlePopupClick,
       radius='none'
       classNames={{ content: ['rounded-xl border-0 p-0'] }}
     >
-      <PopoverTrigger className='focus-visible:outline-none'>{children}</PopoverTrigger>
+      <PopoverTrigger className='focus-visible:outline-none'>
+        <button
+          className='hidden group-hover:block'
+          onClick={() => {
+            if (openPopupId) {
+              setOpenPopupId(null);
+            } else {
+              setOpenPopupId(item.id);
+            }
+          }}
+        >
+          <Kebab className='w-6 h-6' />
+        </button>
+      </PopoverTrigger>
       <PopoverContent>
         <div className='flex flex-col text-sm text-slate-700' ref={popoverRef}>
           {goal && (

--- a/components/Popover/Popover.tsx
+++ b/components/Popover/Popover.tsx
@@ -1,4 +1,4 @@
-import { ListTodoButtons, Todo } from '@/types/ListTodo/Todos';
+import { ListTodoButtons, Todo } from '@/types/Todo';
 import { Popover as NextPopover, PopoverTrigger, PopoverContent } from '@nextui-org/react';
 import { Dispatch, ReactNode, useEffect, useRef } from 'react';
 

--- a/components/ProgressBar/ProgressBar.tsx
+++ b/components/ProgressBar/ProgressBar.tsx
@@ -1,0 +1,14 @@
+import { Progress } from '@nextui-org/react';
+
+type ProgressBarProps = {
+  value: number;
+};
+
+export default function ProgressBar({ value }: ProgressBarProps) {
+  return (
+    <div className='flex items-center gap-2 bg-white rounded-[13px] px-[9px]'>
+      <Progress aria-label='progress' size='sm' value={value} classNames={{ indicator: ['bg-slate-900'] }} />
+      <span className='text-xs font-semibold text-slate-900'>{`${Number(value.toFixed(1))}%`}</span>
+    </div>
+  );
+}

--- a/types/Todo.ts
+++ b/types/Todo.ts
@@ -5,10 +5,10 @@ export type Todos = {
 };
 
 export type Todo = {
-  noteId: number;
-  done?: boolean;
-  linkUrl?: string;
-  fileUrl?: string;
+  noteId: number | null;
+  done: boolean;
+  linkUrl?: string | null;
+  fileUrl?: string | null;
   title: string;
   id: number;
   goal?: Goal;

--- a/types/Todo.ts
+++ b/types/Todo.ts
@@ -22,3 +22,5 @@ export type Goal = {
   id: number;
   title: string;
 };
+
+export type ListTodoButtons = 'file' | 'link' | 'note write' | 'done' | 'note' | 'edit' | 'delete' | 'note read';


### PR DESCRIPTION
## #️⃣연관된 이슈

- #30 
- close #30 
## 📝작업 내용
- [x] 기존의 TodoList에 사용했던 popover를 컴포넌트화 해서 따로 빼두었습니다.
- [x] 기존의 팝업은 2개였는데 추가로 변경 할 수 있게 goal(boolean) 프롭을 내려주면 됩니다.
- [x] handleclick함수 하나 내려줘야해요 페이지 단에서 저 popup 의 처리를 해주기위해서..
- [x] <Popover>버튼 svg 캐밥 넣어주시면 됩니다!</Popover>

### 스크린샷 (선택)
![image](https://github.com/slide-todo/slide-todo/assets/148178373/288e85d6-2b58-41ce-bd6f-8f1b61374038)

## 💬리뷰 요구사항(선택)

테스트 코드 참고 바래요 

'use client';

import Popover from '@/components/Popover/Popover';
import { mock } from './mock';
import { Kebab } from '@/assets/svgs';
import { useState } from 'react';
const { todos } = mock;

export default function TestPage() {
  const [openPopupGoal, setOpenPopupGoal] = useState<number | null>(null);
  const handleButtonClick = (buttonType: string, id: number) => {
    console.log(buttonType, id);
  };

  return (
    <main className='min-h-screen w-full'>
      <div>
        <Popover
          handlePopupClick={handleButtonClick}
          setOpenPopupId={setOpenPopupGoal}
          openPopupId={openPopupGoal}
          item={todos[1]}
          goal
        >
          <button
            className='w-full flex justify-center'
            onClick={() => {
              if (openPopupGoal) {
                setOpenPopupGoal(null);
              } else {
                setOpenPopupGoal(1);
              }
            }}
          >
            <Kebab className='w-6 h-6' />
          </button>
        </Popover>
      </div>
    </main>
  );
}

