### PR TITLE
feat: 공용 컴포넌트 Popup 으로 ConfirmPopup 컴포넌트 구현

### DIFF
--- a/assets/svgs/Cancel.tsx
+++ b/assets/svgs/Cancel.tsx
@@ -1,0 +1,7 @@
+import React, { SVGProps } from 'react';
+export const Cancel = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns='http://www.w3.org/2000/svg' width='16' height='15' viewBox='0 0 16 15' fill='none' {...props}>
+    <path d='M1.5 1L14.5 14' stroke='#64748B' strokeWidth='1.8' strokeLinecap='round' />
+    <path d='M14.5 1L1.5 14' stroke='#64748B' strokeWidth='1.8' strokeLinecap='round' />
+  </svg>
+);

--- a/assets/svgs/index.ts
+++ b/assets/svgs/index.ts
@@ -19,3 +19,4 @@ export * from './SideFoldButton';
 export * from './Rectangles';
 export * from './IcArrowDown';
 export * from './ArrowRight';
+export * from './Cancel';

--- a/components/Popup/ConfirmPopup.tsx
+++ b/components/Popup/ConfirmPopup.tsx
@@ -1,0 +1,95 @@
+import { RefObject, useEffect } from 'react';
+import Button from '../Buttons/Button';
+import { Cancel } from '@/assets/svgs';
+
+type ConfirmPopupProps = {
+  dialogRef: RefObject<HTMLDialogElement>;
+  confirmText: string;
+  description?: string;
+  confirm?: boolean;
+  onConfirmClick: (confirm: string) => void;
+};
+
+export default function ConfirmPopup({
+  dialogRef,
+  confirmText,
+  description,
+  confirm = false,
+  onConfirmClick,
+}: ConfirmPopupProps) {
+  const handlePopupClose = () => {
+    if (!dialogRef.current) return;
+    dialogRef.current.close();
+  };
+
+  useEffect(() => {
+    const outSideClick = (e: MouseEvent) => {
+      if (!dialogRef.current) return;
+      if (dialogRef.current && !dialogRef.current.contains(e.target as Node)) {
+        dialogRef.current.close();
+      }
+    };
+    const handleCloseEvent = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onConfirmClick('cancel');
+      }
+    };
+
+    document.addEventListener('mousedown', outSideClick);
+    if (dialogRef.current) {
+      dialogRef.current.addEventListener('keydown', handleCloseEvent);
+    }
+    return () => {
+      document.removeEventListener('mousedown', outSideClick);
+      if (dialogRef.current) {
+        dialogRef.current.removeEventListener('keydown', handleCloseEvent);
+      }
+    };
+  }, [dialogRef, onConfirmClick]);
+
+  return (
+    <dialog className='rounded-lg z-100' ref={dialogRef}>
+      <div className=' flex w-[402px] p-6'>
+        <div className='w-full flex flex-col justify-between gap-6'>
+          <div className='flex justify-end'>
+            <button
+              onClick={() => {
+                onConfirmClick('cancel');
+                handlePopupClose();
+              }}
+            >
+              <Cancel className='w-[13px] h-[13px]' />
+            </button>
+          </div>
+          <div className='flex flex-col items-center text-slate-800'>
+            <span>{confirmText}</span>
+            <span>{description}</span>
+          </div>
+          <div data-confirm={confirm} className='flex gap-2 justify-end data-[confirm=true]:justify-center'>
+            {confirm && (
+              <Button
+                onClick={() => {
+                  onConfirmClick('cancel');
+                  handlePopupClose();
+                }}
+                size='sm'
+              >
+                취소
+              </Button>
+            )}
+            <Button
+              onClick={() => {
+                onConfirmClick('ok');
+                handlePopupClose();
+              }}
+              size='sm'
+              variant='solid'
+            >
+              확인
+            </Button>
+          </div>
+        </div>
+      </div>
+    </dialog>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -21,3 +21,7 @@
     text-wrap: balance;
   }
 }
+
+button:focus-visible {
+  outline: 0 none;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,6 +17,9 @@ const config: Config = {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
         'gradient-conic': 'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
       },
+      zIndex: {
+        '100': '100',
+      },
     },
   },
   darkMode: 'class',


### PR DESCRIPTION
## #️⃣연관된 이슈

- #39 
- close #39 

## 📝작업 내용

- [ ] figma의 시안대로 버튼의 위치 선정에 data-* 를 썻습니다.
- [ ] prop 중 confirm 지우면 버튼이 우측 하단 한개만 랜더링됩니다.
- [ ] dialog를 사용하여 만들어서 ref를 넘겨주어야 합니다.
![image](https://github.com/slide-todo/slide-todo/assets/148178373/ebe8663d-c6ad-4e37-b343-d57db6b54734)
![image](https://github.com/slide-todo/slide-todo/assets/148178373/61819b98-3613-44fd-99a4-0ccca9879a23)
![image](https://github.com/slide-todo/slide-todo/assets/148178373/d8306130-dfd9-4567-97ec-3ec2f809587f)


## 💬리뷰 요구사항(선택)
테스트 페이지 코드입니다.
```

'use client';

import ConfirmPopup from '@/components/Popup/ConfirmPopup';
import { useRef } from 'react';

export default function TestPage() {
  const confirmRef = useRef<HTMLDialogElement | null>(null);

  const handleConfirmOpen = () => {
    if (!confirmRef.current) return;
    confirmRef.current.showModal();
  };
  const handleConfirm = (request: string) => {
    console.log(request);
  };

  return (
    <main className='flex min-h-screen w-full bg-slate-300 justify-center'>
      <button onClick={handleConfirmOpen}>컨펌 열기</button>
      <ConfirmPopup
        dialogRef={confirmRef}
        confirmText={'정말로 나가시겠습니까?'}
        description={'작성된 내용이 모두 삭제됩니다.'}
        onConfirmClick={handleConfirm}
      />
    </main>
  );
}
```

