### PR TITLE
next auth accessToken refresh 및 요청 처음에만 보내고 그 다음부턴 저장된 token으로 보내기

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,6 +1,35 @@
 import CredentialsProvider from 'next-auth/providers/credentials';
 import NextAuth from 'next-auth';
 import { signin } from '@/lib/api/auth';
+import { instance } from '@/lib/api/axios';
+
+// 세션 유효기간 30분
+function getExpieryTime() {
+  const date = new Date();
+  date.setMinutes(date.getMinutes() + 30);
+  return date.getTime();
+}
+
+// accessToken refreshToken으로 token 다시 받아와 반환
+async function refreshAccessToken(token: any) {
+  try {
+    const { data } = await instance.post('/auth/tokens', undefined, {
+      headers: { Authorization: `Bearer ${token.refreshToken}` },
+    });
+    return {
+      ...token,
+      accessToken: data.accessToken,
+      accessTokenExpieryTime: getExpieryTime(),
+      refreshToken: data.refreshToken,
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      ...token,
+      error: 'RefreshAccessTokenError',
+    };
+  }
+}
 
 const handler = NextAuth({
   // 로그인 타입
@@ -20,10 +49,24 @@ const handler = NextAuth({
       },
     }),
   ],
+  // 엑세스 토큰 유효성 검사 한 뒤 accesstoken 재갱신
   secret: process.env.NEXTAUTH_SECRET,
   callbacks: {
+    // 초반에 accesstoken 만료시간 정해줌  뒤에서 만료시간이 지나면 refreshToken
+    // getSession, setServerSession, useSession 호출 시 발생
     async jwt({ token, user }) {
-      return { ...token, ...user };
+      // 로그인 시 실행
+      if (user) {
+        token.accessTokenExpieryTime = getExpieryTime();
+        return { ...token, ...user };
+      }
+      // 현재보다 이전이라면 refreshToken으로 새 token 받아와서 accessToken및 refreshToken및 만료시간 정해줌
+      if (new Date().getTime() > (token.accessTokenExpieryTime as number)) {
+        const res = await refreshAccessToken(token);
+        return res;
+      }
+
+      return { ...token };
     },
     async session({ session, token }) {
       session.user = token as any;
@@ -34,6 +77,15 @@ const handler = NextAuth({
   // custom page
   pages: {
     signIn: '/signin',
+    error: '/error',
+  },
+
+  session: {
+    strategy: 'jwt',
+    // 해주고 중간에 새로고침 하게 되면 session 다시 요청하게 됨
+    // To Do: 새로고침 해도 session 다시 요청 안하게
+    // To Do: session 만료 되기 전에 refreshToken으로 다시 가져오기
+    // maxAge: 60 * 30,
   },
 });
 

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+export default function Error() {
+  return <h1>Something went wrong!</h1>;
+}

--- a/components/CardNote/CardNote.tsx
+++ b/components/CardNote/CardNote.tsx
@@ -51,6 +51,7 @@ export default function CardNote({ noteList }: { noteList: Note[] }) {
       <NoteRead dialogRef={noteRef} data={noteData} />
       {noteList.map((item) => (
         <div
+          key={item.id}
           className='bg-white p-6 w-full max-w-[792px] border-[1px] rounded-xl text-left cursor-pointer'
           onClick={() => noteMutate(item.id)}
         >

--- a/components/CardNote/CardNote.tsx
+++ b/components/CardNote/CardNote.tsx
@@ -50,8 +50,8 @@ export default function CardNote({ noteList }: { noteList: Note[] }) {
       />
       <NoteRead dialogRef={noteRef} data={noteData} />
       {noteList.map((item) => (
-        <button
-          className='bg-white p-6 w-full max-w-[792px] border-[1px] rounded-xl text-left'
+        <div
+          className='bg-white p-6 w-full max-w-[792px] border-[1px] rounded-xl text-left cursor-pointer'
           onClick={() => noteMutate(item.id)}
         >
           <div className='flex justify-between items-center mb-4'>
@@ -74,7 +74,7 @@ export default function CardNote({ noteList }: { noteList: Note[] }) {
               <span className='text-xs font-normal'>{item.todo.title}</span>
             </div>
           </div>
-        </button>
+        </div>
       ))}
     </>
   );

--- a/lib/api/axios.ts
+++ b/lib/api/axios.ts
@@ -11,9 +11,18 @@ export const axiosAuth = axios.create({
   baseURL: BASE_URL,
 });
 
+let cachedSession: any;
+
+const getCachedSession = async () => {
+  if (!cachedSession) {
+    cachedSession = await getSession();
+  }
+  return cachedSession;
+};
+
 axiosAuth.interceptors.request.use(
   async (config) => {
-    const session = await getSession();
+    const session = await getCachedSession();
     if (session && !config.headers['Authorization']) {
       config.headers['Authorization'] = `Bearer ${session?.user?.accessToken}`;
     }
@@ -26,11 +35,11 @@ axiosAuth.interceptors.response.use(
   (response) => response,
   async (error) => {
     const session = await getSession();
-    const prevRequest = error?.config;
+    // const prevRequest = error?.config;
     // accessToken 권한 없음
     // refreshToken으로 accessToken 다시 발급
     // 발급받은것 으로 session 다시 설정
-    if (error?.response?.status === 401 && !prevRequest?.sent) {
+    if (error?.response?.status === 401) {
       signOut();
       // Todo: fix
       // prevRequest.sent = true;


### PR DESCRIPTION
## #️⃣연관된 이슈

- #100 
- close #100

## 📝작업 내용

- [ ] nextAuth 에서 세션 만료 시간 지정해주고 만료 시 refreshToken 사용해 token 재구성 해줌
- [ ] 변수에 session 담아서 한번만 보내게 처리, 새로고침 했을 때도 세션 가지고 있는 것으로 요청하게 해 주고 싶었는데 방법을 찾지 못함, zustand는 클라이언트측 상태관리라 사용 불가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
