### PR TITLE
이메일 길때 말줄임, 로그인 할때 이전 토큰으로 로그인 

### DIFF
--- a/app/(pages)/dashboard/page.tsx
+++ b/app/(pages)/dashboard/page.tsx
@@ -15,7 +15,7 @@ export default function Dashboard() {
         <div className='w-full'>
           <RecentlyTodo />
         </div>
-        <div className='w-full relative max-w-[1200px] bg-white rounded-xl py-4 px-6 min-h-[calc(100vh-612px)] md:min-h-[calc(100vh-362px)]'>
+        <div className='w-full relative max-w-[1200px] bg-white rounded-xl py-4 px-6 min-h-[calc(100vh-344px)] md:min-h-[calc(100vh-362px)] flex flex-col'>
           <div className='flex justify-start gap-[6px] items-center mb-4'>
             <div className='w-10 h-10 rounded-[15px] bg-green-500 flex items-center justify-center'>
               <Flag fill='white' />
@@ -24,13 +24,15 @@ export default function Dashboard() {
           </div>
           {isLoading ? (
             <Spinner className='absolute top-[calc(50%-16px)] left-[calc(50%-16px)]' />
-          ) : (
+          ) : goalListReseponse.goals.length ? (
             <div className='lg:grid lg:grid-cols-2 gap-4 flex flex-col'>
               {goalListReseponse.goals.map((goal: Goal, index: number) => {
                 if (index >= 3) return;
                 return <CardGoal key={goal.id} goal={goal} index={index} />;
               })}
             </div>
+          ) : (
+            <div className=' text-sm text-slate-500 flex flex-1 justify-center items-center'>등록한 목표가 없어요</div>
           )}
         </div>
       </main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,8 +4,9 @@ import { DayLogo } from '@/assets/svgs/DayLogo';
 import MainMention from '@/components/Landing/MainMention';
 import ServiceStart from '@/components/Landing/ServiceStart';
 import WaveText from '@/components/Landing/WaveText';
+import { useSignout } from '@/hooks/useSignout';
 import { motion } from 'framer-motion';
-import { signIn, signOut, useSession } from 'next-auth/react';
+import { signIn, useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 
 export default function Home() {
@@ -20,7 +21,7 @@ export default function Home() {
           <button onClick={() => signIn()}>{user.data ? '이용하기' : 'Sign in'}</button>
           <span>|</span>
           {user.data ? (
-            <button onClick={() => signOut()}>Logout</button>
+            <button onClick={() => useSignout()}>Logout</button>
           ) : (
             <button onClick={() => router.push('/signup')}>Sign up</button>
           )}

--- a/components/RecentlyTodo/RecentlyTodo.tsx
+++ b/components/RecentlyTodo/RecentlyTodo.tsx
@@ -59,7 +59,9 @@ export default function RecentlyTodo() {
                 <ListTodo showGoal todos={todoResponse?.todos} onButtonClick={handleListPopupClick}></ListTodo>
               </div>
             ) : (
-              <div className='flex items-center justify-center text-sm text-slate-500 flex-1'>최근 등록한 할 일이 없어요</div>
+              <div className='flex items-center justify-center text-sm text-slate-500 flex-1'>
+                최근 등록한 할 일이 없어요
+              </div>
             )}
             <div className='absolute bottom-4 h-[51px] w-[calc(100%-48px)] bg-gradient-to-b from-white/0 to-white/100 pointer-events-none' />
           </>

--- a/components/RecentlyTodo/RecentlyTodo.tsx
+++ b/components/RecentlyTodo/RecentlyTodo.tsx
@@ -37,7 +37,7 @@ export default function RecentlyTodo() {
       />
       <NoteRead dialogRef={noteRef} data={noteData} />
       <Modal onClose={onClose} isOpen={isOpen} modalType={modalType} items={todo} />
-      <div className='relative w-full h-[250px] bg-white rounded-xl border-1 border-slate-100 px-6 py-4 flex flex-col gap-4 max-w-[1200px]'>
+      <div className='relative w-full h-[250px] bg-white rounded-xl border-1 border-slate-100 px-6 py-4 flex flex-col gap-4 max-w-[1200px] flex flex-col'>
         {isLoading ? (
           <Spinner className='absolute top-[calc(50%-16px)] left-[calc(50%-16px)]' />
         ) : (
@@ -59,9 +59,7 @@ export default function RecentlyTodo() {
                 <ListTodo showGoal todos={todoResponse?.todos} onButtonClick={handleListPopupClick}></ListTodo>
               </div>
             ) : (
-              <div className='h-[154px] flex items-center justify-center'>
-                <p className='text-sm text-slate-500'>최근 등록한 할 일이 없어요</p>
-              </div>
+              <div className='flex items-center justify-center text-sm text-slate-500 flex-1'>최근 등록한 할 일이 없어요</div>
             )}
             <div className='absolute bottom-4 h-[51px] w-[calc(100%-48px)] bg-gradient-to-b from-white/0 to-white/100 pointer-events-none' />
           </>

--- a/components/SideMenu/SideMenu.tsx
+++ b/components/SideMenu/SideMenu.tsx
@@ -117,8 +117,12 @@ export default function SideMenu() {
                 <Profile className='h-8 w-8 md:h-16 md:w-16 shrink-0' />
                 <div className='flex md:flex-col md:gap-2 w-full justify-between items-end md:items-start'>
                   <div className='flex flex-col'>
-                    <span className='text-slate-800 text-xs md:text-sm font-semibold'>{userData?.name}</span>
-                    <span className='text-slate-600 text-xs md:text-sm font-medium'>{userData?.email}</span>
+                    <span className='text-slate-800 text-xs md:text-sm font-semibold overflow-hidden text-ellipsis md:max-w-[152px]'>
+                      {userData?.name}
+                    </span>
+                    <span className='text-slate-600 text-xs md:text-sm font-medium overflow-hidden text-ellipsis md:max-w-[152px]'>
+                      {userData?.email}
+                    </span>
                   </div>
                   <button
                     type='button'

--- a/components/SideMenu/SideMenu.tsx
+++ b/components/SideMenu/SideMenu.tsx
@@ -13,7 +13,7 @@ import MixedInput from '../Input/MixedInput';
 import { queryKey, useGetQuery } from '@/queries/query';
 import { useSideMenuOpen } from '@/stores/useSideMenuOpen';
 import { useDisclosure } from '@nextui-org/react';
-import { signOut } from 'next-auth/react';
+import { useSignout } from '@/hooks/useSignout';
 
 export default function SideMenu() {
   const queryClient = useQueryClient();
@@ -123,7 +123,7 @@ export default function SideMenu() {
                   <button
                     type='button'
                     className='text-slate-400 text-xs font-normal md:text-left'
-                    onClick={() => signOut()}
+                    onClick={() => useSignout()}
                   >
                     로그아웃
                   </button>

--- a/hooks/useSignout.ts
+++ b/hooks/useSignout.ts
@@ -1,0 +1,6 @@
+import { signOut } from 'next-auth/react';
+
+export const useSignout = () => {
+  localStorage.clear();
+  signOut();
+};

--- a/lib/api/axios.ts
+++ b/lib/api/axios.ts
@@ -1,5 +1,6 @@
+import { useSignout } from '@/hooks/useSignout';
 import axios from 'axios';
-import { getSession, signOut } from 'next-auth/react';
+import { getSession } from 'next-auth/react';
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
@@ -48,7 +49,7 @@ axiosAuth.interceptors.response.use(
   (response) => response,
   async (error) => {
     // refreshToken 유효하지 않으면 signOut()
-    if (error.status === 401) signOut();
+    if (error.status === 401) useSignout();
     return Promise.reject(error);
   }
 );


### PR DESCRIPTION
## #️⃣연관된 이슈

- #152 
- #154 
- close #152 
- close #154


## 📝작업 내용

- [ ] 유저 로그인 유무에 따라 랜딩페이지 header 바꿔주었습니다.
- [ ] signout 할 때 localStorage 초기화 하였습니다.
- [ ] 이메일 길면 말줄임표 해주었습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
